### PR TITLE
Fix completion script paths and names

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -28,9 +28,9 @@ override_dh_auto_install:
 	cp -r "runtime/grammars" "debian/helix/usr/lib/helix/runtime/"
 	install -Dm0644 "runtime/tutor" -t "debian/helix/usr/lib/helix/runtime/"
 
-	install -Dm0644 "contrib/completion/hx.bash" "debian/helix/usr/share/bash-completion/completions/helix"
-	install -Dm0644 "contrib/completion/hx.fish" "debian/helix/usr/share/fish/vendor_completions.d/helix.fish"
-	install -Dm0644 "contrib/completion/hx.zsh" "debian/helix/usr/share/zsh/site-functions/_helix"
+	install -Dm0644 "contrib/completion/hx.bash" "debian/helix/usr/share/bash-completion/completions/hx"
+	install -Dm0644 "contrib/completion/hx.fish" "debian/helix/usr/share/fish/vendor_completions.d/hx.fish"
+	install -Dm0644 "contrib/completion/hx.zsh" "debian/helix/usr/share/zsh/vendor-completions/_hx"
 
 	install -Dm0644 "contrib/Helix.desktop" "debian/helix/usr/share/applications/Helix.desktop"
 	install -Dm0644 "contrib/helix.png" "debian/helix/usr/share/icons/hicolor/128x128/apps/helix.png"


### PR DESCRIPTION
Fixes #11

A small fix as discussed in the issue above, changed zsh install location to the debian default and changed script names to reflect binary names.